### PR TITLE
Drop support for model concerns

### DIFF
--- a/lib/rbs_heuristic_prototype/filters/rails_concerns_filter.rb
+++ b/lib/rbs_heuristic_prototype/filters/rails_concerns_filter.rb
@@ -41,8 +41,6 @@ module RbsHeuristicPrototype
         names = case module_type_for(mod)
                 when :controller
                   self_types_for_controller(mod)
-                when :model
-                  self_types_for_model(mod)
                 else
                   []
                 end
@@ -60,14 +58,6 @@ module RbsHeuristicPrototype
         end
       end
 
-      def self_types_for_model(mod)
-        if const_get("ApplicationRecord") && !(mod > ApplicationRecord)
-          [TypeName("::ApplicationRecord")]
-        else
-          [TypeName("::ActiveRecord::Base")]
-        end
-      end
-
       def module_type_for(mod)
         source_location = Kernel.const_source_location(mod.name.to_s)
         return :unknown unless source_location
@@ -77,8 +67,6 @@ module RbsHeuristicPrototype
         case filename
         when %r{app/controllers/concerns}
           :controller
-        when %r{app/models/concerns}
-          :model
         else
           :unknown
         end

--- a/sig/rbs_heuristic_prototype/filters/rails_concerns_filter.rbs
+++ b/sig/rbs_heuristic_prototype/filters/rails_concerns_filter.rbs
@@ -7,8 +7,7 @@ module RbsHeuristicPrototype
       def concern?: (Module mod) -> bool
       def self_types_for: (Module mod) -> Array[RBS::AST::Declarations::Module::Self]
       def self_types_for_controller: (Module mod) -> Array[RBS::TypeName]
-      def self_types_for_model: (Module mod) -> Array[RBS::TypeName]
-      def module_type_for: (Module mod) -> (:controller | :model | :unknown)
+      def module_type_for: (Module mod) -> (:controller | :unknown)
     end
   end
 end

--- a/spec/rbs_heuristic_prototype/filters/app/models/application_record.rb
+++ b/spec/rbs_heuristic_prototype/filters/app/models/application_record.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require "active_record"
-require_relative "concerns/discardable"
-
-class ApplicationRecord < ActiveRecord::Base
-  include Discardable
-end

--- a/spec/rbs_heuristic_prototype/filters/app/models/concerns/decoratable.rb
+++ b/spec/rbs_heuristic_prototype/filters/app/models/concerns/decoratable.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Decoratable
-  extend ActiveSupport::Concern
-end

--- a/spec/rbs_heuristic_prototype/filters/app/models/concerns/discardable.rb
+++ b/spec/rbs_heuristic_prototype/filters/app/models/concerns/discardable.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Discardable
-  extend ActiveSupport::Concern
-end

--- a/spec/rbs_heuristic_prototype/filters/rails_concerns_filter_spec.rb
+++ b/spec/rbs_heuristic_prototype/filters/rails_concerns_filter_spec.rb
@@ -4,9 +4,6 @@ require "rbs_heuristic_prototype"
 require_relative "app/controllers/application_controller"
 require_relative "app/controllers/concerns/bloggable"
 require_relative "app/controllers/concerns/loginable"
-require_relative "app/models/application_record"
-require_relative "app/models/concerns/decoratable"
-require_relative "app/models/concerns/discardable"
 
 RSpec.describe RbsHeuristicPrototype::Filters::RailsConcernsFilter do
   describe "#apply" do
@@ -45,38 +42,6 @@ RSpec.describe RbsHeuristicPrototype::Filters::RailsConcernsFilter do
         end
 
         it "converts the deep class definition to the nested definition" do
-          expect(subject).to eq_in_rbs expected
-        end
-      end
-    end
-
-    context "When a model concern given" do
-      context "When the concern is used in the ApplicationRecord" do
-        let(:sig_file) { Pathname(__dir__) / "sig/discardable.rbs" }
-        let(:expected) do
-          <<~RBS
-            module Discardable : ::ActiveRecord::Base
-              extend ActiveSupport::Concern
-            end
-          RBS
-        end
-
-        it "sets ActiveRecord::Base as module-self-types" do
-          expect(subject).to eq_in_rbs expected
-        end
-      end
-
-      context "When the concern is not used in the ApplicationRecord" do
-        let(:sig_file) { Pathname(__dir__) / "sig/decoratable.rbs" }
-        let(:expected) do
-          <<~RBS
-            module Decoratable : ::ApplicationRecord
-              extend ActiveSupport::Concern
-            end
-          RBS
-        end
-
-        it "sets ApplicationRecord as module-self-types" do
           expect(subject).to eq_in_rbs expected
         end
       end

--- a/spec/rbs_heuristic_prototype/filters/sig/decoratable.rbs
+++ b/spec/rbs_heuristic_prototype/filters/sig/decoratable.rbs
@@ -1,3 +1,0 @@
-module Decoratable
-  extend ActiveSupport::Concern
-end

--- a/spec/rbs_heuristic_prototype/filters/sig/discardable.rbs
+++ b/spec/rbs_heuristic_prototype/filters/sig/discardable.rbs
@@ -1,3 +1,0 @@
-module Discardable
-  extend ActiveSupport::Concern
-end


### PR DESCRIPTION
The current implementation expects all model concerns is used for ActiveRecord.  But model concerns are not only for ActiveRecord.

This cancels the support for model concerns temporariliy.